### PR TITLE
Add feature to keep suggestions after approving/rejecting

### DIFF
--- a/src/commands/Staff/approve.js
+++ b/src/commands/Staff/approve.js
@@ -207,8 +207,19 @@ module.exports = class ApproveCommand extends Command {
 
     try {
       message.channel.send(`Suggestion **${sID}** has been approved.`).then(m => m.delete({ timeout: 5000 }));
-      sMessage.edit(approvedEmbed).then(m => m.delete({ timeout: 5000 }));
-      suggestionsLogs.send(logsEmbed);
+
+      if (settings.keepLogs || (!settings.keepLogs && !suggestionsLogs)) {
+        const logEmbed = new MessageEmbed(logsEmbed)
+          .setTitle('Suggestion Approved');
+        await sMessage.edit(logEmbed);
+        await sMessage.reactions.removeAll();
+      }
+
+      if (!settings.keepLogs && suggestionsLogs) {
+        await sMessage.edit(approvedEmbed).then(m => m.delete({ timeout: 5000 }));
+        await suggestionsLogs.send(logsEmbed);
+      }
+
       await this.client.mongodb.helpers.suggestions.handleGuildSuggestion(approveSuggestion);
       await guild.members.fetch({ user: userID, cache: false });
       if (settings.dmResponses) submitter.send(dmEmbed);

--- a/src/commands/Staff/reject.js
+++ b/src/commands/Staff/reject.js
@@ -210,8 +210,19 @@ module.exports = class RejectCommand extends Command {
 
     try {
       message.channel.send(`Suggestion **${sID}** has been rejected.`).then(m => m.delete({ timeout: 5000 }));
-      sMessage.edit(rejectedEmbed).then(m => m.delete({ timeout: 5000 }));
-      suggestionsLogs.send(logsEmbed);
+
+      if (settings.keepLogs || (!settings.keepLogs && !suggestionsLogs)) {
+        const logEmbed = new MessageEmbed(logsEmbed)
+          .setTitle('Suggestion Rejected');
+        await sMessage.edit(logEmbed);
+        await sMessage.reactions.removeAll();
+      }
+
+      if (!settings.keepLogs && suggestionsLogs) {
+        await sMessage.edit(rejectedEmbed).then(m => m.delete({ timeout: 5000 }));
+        await suggestionsLogs.send(logsEmbed);
+      }
+
       await this.client.mongodb.helpers.suggestions.handleGuildSuggestion(rejectSuggestion);
       await guild.members.fetch({ user: userID, cache: false });
       if (settings.dmResponses) submitter.send(dmEmbed);

--- a/src/providers/mongodb/models/settings.js
+++ b/src/providers/mongodb/models/settings.js
@@ -38,7 +38,7 @@ const settingsSchema = mongoose.Schema({
   },
   keepLogs: {
     type: Boolean,
-    default: false
+    default: true
   }
 });
 

--- a/src/providers/mongodb/models/settings.js
+++ b/src/providers/mongodb/models/settings.js
@@ -35,6 +35,10 @@ const settingsSchema = mongoose.Schema({
   fetchedMessages: {
     type: Boolean,
     default: false
+  },
+  keepLogs: {
+    type: Boolean,
+    default: false
   }
 });
 


### PR DESCRIPTION
Per popular request, I'm deciding to implement this feature into v2 as it's relatively easily and doesn't break things.

How this will work:

If the user enables the `keepLogs` configuration, then suggestions will be approved/rejected on the spot and updated with the results. However, the results will no longer be posted to the logs channel, regardless if there's one set. 

If the user disables the `keepLogs` configuration, then suggestions will be approved/rejected, the original message will be deleted, but the results will be posted to the logs channel (if set).

If the logs channel isn't set, then the bot will follow the same process as if `keepLogs` was enabled.