### PR TITLE
Add nodemon as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "zlib-sync": "^0.1.7"
   },
   "devDependencies": {
-    "eslint": "8.10.0",
+    "eslint": "8.12.0",
     "nodemon": "^2.0.15",
     "ts-node": "10.7.0"
   }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "eslint": "8.10.0",
+    "nodemon": "^2.0.15",
     "ts-node": "10.7.0"
   }
 }


### PR DESCRIPTION
The script `dev` in package.json requires nodemon to run, so users without nodemon installed globally can now use the command without separately installing it.
